### PR TITLE
Remove whitespace on header include

### DIFF
--- a/components/MicroCanvas2D/uCanvas2D_GUI_Components/simple_menu/simple_menu.c
+++ b/components/MicroCanvas2D/uCanvas2D_GUI_Components/simple_menu/simple_menu.c
@@ -11,7 +11,7 @@
 #include "uCanvas_User_IO.h"
 #include "simple_menu.h"
 #include "ssd1306.h"
-#include "esp_system.h "
+#include "esp_system.h"
 void menu_task(selection_menu_obj_t* menu_obj);
 void create_menu(selection_menu_obj_t* menu_obj,uCanvas_universal_obj_t* cursor_object){
     char buf[32]={0};


### PR DESCRIPTION
Remove trailing whitespace in include, that was making compilation to fail on linux.